### PR TITLE
feat(iron_codegen_llvm): initial LLVM experiments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -88,6 +88,9 @@ name = "forge"
 version = "0.1.0"
 dependencies = [
  "clap",
+ "iron_ast",
+ "iron_codegen",
+ "iron_codegen_llvm",
  "iron_parser",
 ]
 

--- a/forge/Cargo.toml
+++ b/forge/Cargo.toml
@@ -8,4 +8,7 @@ edition = "2018"
 
 [dependencies]
 clap = "2.33.3"
+iron_ast = { path = "../iron_ast" }
 iron_parser = { path = "../iron_parser" }
+iron_codegen = { path = "../iron_codegen" }
+iron_codegen_llvm = { path = "../iron_codegen_llvm" }

--- a/forge/src/main.rs
+++ b/forge/src/main.rs
@@ -2,22 +2,62 @@ extern crate clap;
 extern crate iron_parser;
 
 use clap::{App, Arg};
+use iron_ast::IronASTNode;
+use iron_codegen::{IronCodegenError, IronCompilerBackend};
+use iron_codegen_llvm::IronCompilerBackendLLVM;
 use iron_parser::Module;
+use std::collections::HashMap;
 use std::str::FromStr;
 
 fn main() {
-    let matches = App::new("ironc")
-        .version("0.1")
-        .about("Compiles an Iron module.")
-        .arg(
-            Arg::with_name("INPUT")
-                .help("Path to file containing Iron source code")
-                .required(true),
-        )
-        .get_matches();
+    // let matches = App::new("ironc")
+    //     .version("0.1")
+    //     .about("Compiles an Iron module.")
+    //     .arg(
+    //         Arg::with_name("INPUT")
+    //             .help("Path to file containing Iron source code")
+    //             .required(true),
+    //     )
+    //     .get_matches();
 
-    let path = matches.value_of("INPUT").expect("expected INPUT");
-    let _module = Module::from_str(path).expect("module should be parsed successfully");
+    // let path = matches.value_of("INPUT").expect("expected INPUT");
+    // let _module = Module::from_str(path).expect("module should be parsed successfully");
 
-    // println!("{:#?}", module);
+    let hello: IronASTNode = IronASTNode::FunctionDefinition {
+        public: true,
+        identifier: "hello".to_string(),
+        parameters: vec![IronASTNode::FunctionParameter {
+            label: None,
+            name: "name".to_string(),
+            kind: "String".to_string(),
+        }],
+        statements: vec![
+            IronASTNode::VariableDefinition {
+                identifier: "result".to_string(),
+                mutable: false,
+                value: Box::new(IronASTNode::LiteralString("Hello, {name}!".to_string())),
+            },
+            IronASTNode::ReturnStatement {
+                expr: Box::new(IronASTNode::Identifier("result".to_string())),
+            },
+        ],
+    };
+
+    // Create the function hashmap.
+    let mut functions: HashMap<String, IronASTNode> = HashMap::new();
+    functions.insert("hello".to_string(), hello);
+
+    // Create the module.
+    let module: IronASTNode = IronASTNode::Module {
+        identifier: "hello".to_string(),
+        functions,
+    };
+
+    // Compile the module.
+    let mut llvm = IronCompilerBackendLLVM::new();
+    let result = llvm.compile_module(module);
+    match result {
+        Ok(_) => println!("Compiled successfully!"),
+        Err(err) => println!("There was an error compiling this module."),
+    }
 }

--- a/iron_ast/src/ast.rs
+++ b/iron_ast/src/ast.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 
+#[derive(Debug)]
 pub enum Operator {
     Add,
     Sub,
@@ -9,6 +10,7 @@ pub enum Operator {
 }
 
 /// Represents a node in an Iron abstract syntax tree (AST).
+#[derive(Debug)]
 pub enum IronASTNode {
     Identifier(String),
 
@@ -205,6 +207,8 @@ pub enum IronASTNode {
 
     /// Represents an Iron module.
     Module {
+        /// Identifier for the module.
+        identifier: String,
         /// Module-level function definitions.
         functions: HashMap<String, IronASTNode>,
     },
@@ -241,6 +245,9 @@ mod tests {
         functions.insert("hello".to_string(), hello);
 
         // Create the module.
-        let _module: IronASTNode = IronASTNode::Module { functions };
+        let _module: IronASTNode = IronASTNode::Module {
+            identifier: "hello".to_string(),
+            functions,
+        };
     }
 }

--- a/iron_codegen/src/error.rs
+++ b/iron_codegen/src/error.rs
@@ -1,8 +1,10 @@
+use iron_ast::IronASTNode;
 use std::{error::Error, fmt};
 
 #[derive(Debug)]
 pub enum IronCodegenError {
-    Unexpected,
+    Unknown,
+    UnexpectedASTNode(IronASTNode),
 }
 
 impl fmt::Display for IronCodegenError {
@@ -11,7 +13,8 @@ impl fmt::Display for IronCodegenError {
             f,
             "{}",
             match self {
-                IronCodegenError::Unexpected => "unexpected",
+                IronCodegenError::UnexpectedASTNode(_) => "unexpected AST node",
+                IronCodegenError::Unknown => "unknown",
             }
         )
     }

--- a/iron_codegen/src/lib.rs
+++ b/iron_codegen/src/lib.rs
@@ -7,5 +7,5 @@ use iron_ast::IronASTNode;
 ///
 ///
 pub trait IronCompilerBackend {
-    fn compile_module(ast: IronASTNode) -> Result<(), IronCodegenError>;
+    fn compile_module(&mut self, ast: IronASTNode) -> Result<(), IronCodegenError>;
 }

--- a/iron_codegen_llvm/src/lib.rs
+++ b/iron_codegen_llvm/src/lib.rs
@@ -1,13 +1,58 @@
 extern crate inkwell;
 
+use inkwell::{
+    builder::Builder,
+    context::Context,
+    module::Module,
+    passes::PassManager,
+    types::BasicTypeEnum,
+    values::{BasicValue, BasicValueEnum, FloatValue, FunctionValue, PointerValue},
+    FloatPredicate, OptimizationLevel,
+};
 use iron_ast::IronASTNode;
 use iron_codegen::{IronCodegenError, IronCompilerBackend};
 
-/// LLVM-based Iron compiler backend.
-pub struct IronBackendLLVM;
+trait IronMachineCodeGeneratable {
+    fn generate_code(&self) -> Result<(), IronCodegenError>;
+}
 
-impl IronCompilerBackend for IronBackendLLVM {
-    fn compile_module(node: IronASTNode) -> Result<(), IronCodegenError> {
-        Err(IronCodegenError::Unexpected)
+pub struct IronCompilerBackendLLVM {
+    context: Context,
+}
+
+impl IronCompilerBackendLLVM {
+    pub fn new() -> IronCompilerBackendLLVM {
+        IronCompilerBackendLLVM {
+            context: Context::create(),
+        }
     }
+}
+
+impl IronCompilerBackend for IronCompilerBackendLLVM {
+    fn compile_module(&mut self, ast: IronASTNode) -> Result<(), IronCodegenError> {
+        match ast {
+            IronASTNode::Module {
+                identifier,
+                functions,
+            } => {
+                let mut module = self.context.create_module(identifier.as_str());
+                let _results = functions
+                    .values()
+                    .map(|node| compile_function(&mut module, node));
+                Ok(())
+            }
+            other => Err(IronCodegenError::UnexpectedASTNode(other)),
+        }
+    }
+}
+
+fn compile_function(module: &mut Module, node: &IronASTNode) -> Result<(), IronCodegenError> {
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn test() {}
 }


### PR DESCRIPTION
This PR introduces a very basic implementation of the code generation with LLVM.

**It is very likely that I'm going to end up removing the dependency on [Inkwell](https://github.com/TheDan64/inkwell).** It is an awesome project, but I'm not keen on introducing an _additional_ dependency to interface with LLVM. If I limit it to `llvm-sys`, I could also bump up to LLVM 11.